### PR TITLE
Modify README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,29 @@
 # geospatial repo
 PostGIS 2.1.5 for GreenPlum 5.x+
 
-## Licence
+## License
 This project is developed under GPL v2, because PostGIS is GPL v2.
 
 ## How to compile it
-To compile geospatial form source code, please install the follow third-party
-libraries first by following README.libs.
-For normal use without raster, please install json-c, geos and proj.4
-To enbale raster function, plese install gdal and expat. The minimum version
-requirments are listed in Makefile.version.
+Currently, we support building geospatial on rhel/centos. To compile geospatial form source code, please install the following third-party libraries as described in [README.libs](https://github.com/greenplum-db/geospatial/blob/master/postgis/README.libs).
+For normal use without raster, please install json-c, geos and proj.4.
+To enable raster functionality, please install gdal and expat. The minimum version requirments are listed in [Makefile.version](https://github.com/greenplum-db/geospatial/blob/master/postgis/Makefile.version).
 
-Before setup the geospatial, please make sure the GPDB is installed correctly.
+Before setting up geospatial, please make sure GPDB is installed correctly.
 To compile and install geospatial, use following command:
 
 ```
-./configure --with-pgconfig="Your gpdb location"/bin/pg_config --with-raster --without-topology --prefix=$GPHOME
-make
-make install	
-```
-
-If you build from
-the extended PostGIS-2.x directory, you may compile with the following command:
-
-```
-make USE_PGXS=1 clean all install
+cd postgis/build/postgis-2.1.5/
+./configure --with-pgconfig=$GPHOME/bin/pg_config --with-raster --without-topology --prefix=$GPHOME
+make USE_PGXS=1 clean all install	
 ```
 
 Here USE_PGXS will specify the correct install path to gpdb.
 
+Note that if psql is in path, there is no need to use --use-pgconfig flag.
+
 ## How to use it
-After installing geospatial extention, run the following commands to enable it:
+After installing geospatial extension, run the following commands to enable it:
 
 ```
 psql -d mydatabase -f ${GPHOME}/share/postgresql/contrib/postgis-2.1/postgis.sql
@@ -39,7 +32,7 @@ psql -d mydatabase -f ${GPHOME}/share/postgresql/contrib/postgis-2.1/rtpostgis.s
 psql -d mydatabase -f ${GPHOME}/share/postgresql/contrib/postgis-2.1/raster_comments.sql
 ```
 
-Besides, to configure raster utilities, please set following variables into env of both master and segments. A suggested way to do this is to add those variable settings into your `$GPHOME/greenplum_path.sh` file to ensure they get set in all the segments. After setting them, restart the database.
+To configure raster utilities, please set the following environment variables on the master host and all the segment hosts. A suggested way to do this is to add these variables into your `$GPHOME/greenplum_path.sh` file to ensure they get set in all the segment hosts and the master host. **Make sure that you restart the database after setting them**.
 
 ```
 export GDAL_DATA=$GPHOME/share/gdal
@@ -47,13 +40,13 @@ export POSTGIS_ENABLE_OUTDB_RASTERS=0
 export POSTGIS_GDAL_ENABLED_DRIVERS=DISABLE_ALL
 ```
 
-Note: by default, all the gdal drivers are disabled. To enable specific types of gdal driver, please refer to this [postgis manual](http://postgis.net/docs/manual-2.1/postgis_installation.html#install_short_version). An example can be like this:
+Note: to guarantee that `make check` test cases run correctly, all the gdal drivers are disabled. To enable specific types of gdal drivers for a certain use case, please refer to this [postgis manual](http://postgis.net/docs/manual-2.1/postgis_installation.html#install_short_version). An example can be like this:
 
 ```
 POSTGIS_GDAL_ENABLED_DRIVERS="GTiff PNG JPEG GIF XYZ"
 ```
 
-In near future we plan to move them in GUCs after we backport necessary features onto gpdb repo.
+In near future we plan to create GUCs for these variables after we backport necessary features into the gpdb repository.
 
 ## Sub-directories under planing
 1. postgis
@@ -63,5 +56,6 @@ In near future we plan to move them in GUCs after we backport necessary features
 3. utilities
 
 ## Last update date
-Jingyi Mei, Nov 27th, 2017	
+Jingyi Mei, Nov 28th, 2017	
+
 Kuien Liu, Haozhou Wawng, 26 May 2016

--- a/README.md
+++ b/README.md
@@ -1,17 +1,10 @@
 # geospatial repo
+PostGIS 2.1.5 for GreenPlum 5.x+
 
-## licence
+## Licence
+This project is developed under GPL v2, because PostGIS is GPL v2.
 
-This project is developing under GPL v2, because PostGIS is GPL v2.
-
-## sub-directories under planing
-1. postgis
-  * geometry
-  * raster
-2. trajectory
-3. utilities
-
-## how to compile it
+## How to compile it
 To compile geospatial form source code, please install the follow third-party
 libraries first by following README.libs.
 For normal use without raster, please install json-c, geos and proj.4
@@ -19,57 +12,56 @@ To enbale raster function, plese install gdal and expat. The minimum version
 requirments are listed in Makefile.version.
 
 Before setup the geospatial, please make sure the GPDB is installed correctly.
-To configure the geospatial, please use following command:
+To compile and install geospatial, use following command:
+
 ```
-./configure --with-pgconfig="Your gpdb location"/bin/pg_config --with-raster
---without-topology --prefix=$GPHOME
+./configure --with-pgconfig="Your gpdb location"/bin/pg_config --with-raster --without-topology --prefix=$GPHOME
+make
+make install	
 ```
 
-If configuration is successfully, then please run _make_ to compile the geospatial
-and run make install to install the geospatial to the GPDB. If you build from
-the extended PostGIS-2.x directory, you may compile with following command:
+If you build from
+the extended PostGIS-2.x directory, you may compile with the following command:
+
 ```
 make USE_PGXS=1 clean all install
 ```
+
 Here USE_PGXS will specify the correct install path to gpdb.
 
+## How to use it
+After installing geospatial extention, run the following commands to enable it:
 
-## how to distribute it
-The geospatial has bulit-in function to build the geospatial as a gppkg to allow
-user to install the geospatial directly into GPDB without compiling.
-
-To build the gppkg, please make sure the source code of GPDB is downloaded and
-```make sync_tools``` is run correctly.
-
-After this, go to _package_ folder and run ./build.sh or following command to build the gppkg
-automaticly.
-```
-make BLD_TARGETS="gppkg" \
-	BLD_ARCH="rhel5_x86_64" \
-	BLD_TOP="Your_gpdb_source_location/gpAux" \
-	INSTLOC="Your_gpdb_installation_location/" \
-	gppkg
-```
-
-## how to use it
-After you installed geospatial extention, run following commands to enable it:
 ```
 psql -d mydatabase -f ${GPHOME}/share/postgresql/contrib/postgis-2.1/postgis.sql
 psql -d mydatabase -f ${GPHOME}/share/postgresql/contrib/postgis-2.1/postgis_comments.sql
-psql -d mydatabase -f ${GPHOME}/share/postgresql/contrib/postgis-2.1/spatial_ref_sys.sql
 psql -d mydatabase -f ${GPHOME}/share/postgresql/contrib/postgis-2.1/rtpostgis.sql
 psql -d mydatabase -f ${GPHOME}/share/postgresql/contrib/postgis-2.1/raster_comments.sql
 ```
-Besides, to configure raster utilities, please set following variables into env of both
-master and segments, and restart the databases.
+
+Besides, to configure raster utilities, please set following variables into env of both master and segments. A suggested way to do this is to add those variable settings into your `$GPHOME/greenplum_path.sh` file to ensure they get set in all the segments. After setting them, restart the database.
+
 ```
 export GDAL_DATA=$GPHOME/share/gdal
 export POSTGIS_ENABLE_OUTDB_RASTERS=0
 export POSTGIS_GDAL_ENABLED_DRIVERS=DISABLE_ALL
 ```
 
-In near future we plan to move them in GUCs after we backport necessary features
-onto gpdb repo.
+Note: by default, all the gdal drivers are disabled. To enable specific types of gdal driver, please refer to this [postgis manual](http://postgis.net/docs/manual-2.1/postgis_installation.html#install_short_version). An example can be like this:
 
-## last update date
-	Kuien Liu, Haozhou Wawng, 26 May 2016
+```
+POSTGIS_GDAL_ENABLED_DRIVERS="GTiff PNG JPEG GIF XYZ"
+```
+
+In near future we plan to move them in GUCs after we backport necessary features onto gpdb repo.
+
+## Sub-directories under planing
+1. postgis
+  * geometry
+  * raster
+2. trajectory
+3. utilities
+
+## Last update date
+Jingyi Mei, Nov 27th, 2017	
+Kuien Liu, Haozhou Wawng, 26 May 2016

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ make USE_PGXS=1 clean all install
 
 Here USE_PGXS will specify the correct install path to gpdb.
 
-Note that if psql is in path, there is no need to use --use-pgconfig flag.
+Note that if psql is in path, there is no need to use --with-pgconfig flag.
 
 ## How to use it
 After installing geospatial extension, run the following commands to enable it:

--- a/postgis/README.libs
+++ b/postgis/README.libs
@@ -1,32 +1,23 @@
 # Step 0
-#
+# 
 # make sure you have epel.repo under /etc/yum.repo.d/
 # otherwise you cannot find geos/gdal/proj4 from yum
 
 # Step 1
 
-1. sudo yum install json-c-devel -y
+1. sudo yum install -y json-c-devel
 
-Installed:
-  json-c-devel.x86_64 0:0.11-4.el7_0
-
-
-2. sudo yum install geos-devel -y
-
-Installed:
-  geos-devel.x86_64 0:3.4.2-2.el7
-
-Dependency Installed:
-  geos.x86_64 0:3.4.2-2.el7
+2. sudo yum install -y geos-devel
 
 3. sudo yum install -y proj-devel
 
-Installed:
-  proj-devel.x86_64 0:4.8.0-4.el7
+4. sudo yum install -y expact
+5. sudo yum install -y CUnit CUnit-devel
 
-  Dependency Installed:
-    proj.x86_64 0:4.8.0-4.el7
-
-4. gdal
-
-5. expat
+5. install gdal 1.11.1:
+   wget http://download.osgeo.org/gdal/1.11.1/gdal-1.11.1.tar.gz
+   tar zxf gdal-1.11.1.tar.gz
+   cd gdal-1.11.1
+   ./configure --prefix=$GPHOME (or other place you want, default is /usr/local)
+   make
+   make install

--- a/postgis/README.libs
+++ b/postgis/README.libs
@@ -11,7 +11,7 @@
 
 3. sudo yum install -y proj-devel
 
-4. sudo yum install -y expact
+4. sudo yum install -y expat
 5. sudo yum install -y CUnit CUnit-devel
 
 5. install gdal 1.11.1:


### PR DESCRIPTION
This commit updates the README file from the following perspective:
1. Removed instructions to build gppkg, since it requires make_sync_tool
which is not open source.
2. Removed loading spatial_ref_sys.sql file for enabling geospatial,
since it is not actually used.
3. Add more instructions on setting up raster and gdal driver.
4. Modified some phrases, and reordered some paragraphs.