### PR TITLE
spatial_ref_sys should be replicated table in order to adapt gp6, oth…

### DIFF
--- a/postgis/build/postgis-2.5.2/postgis/postgis.sql.in
+++ b/postgis/build/postgis-2.5.2/postgis/postgis.sql.in
@@ -1924,7 +1924,7 @@ CREATE TABLE spatial_ref_sys (
 	 auth_srid integer,
 	 srtext varchar(2048),
 	 proj4text varchar(2048)
-);
+) DISTRIBUTED REPLICATED;
 
 -----------------------------------------------------------------------
 -- POPULATE_GEOMETRY_COLUMNS()


### PR DESCRIPTION
…erwise we will get 'function cannot execute on a QE slice because it accesses relation' error