### PR TITLE
fixing building error in gcc-7

### DIFF
--- a/postgis/build/postgis-2.5.4/raster/rt_pg/rtpg_mapalgebra.c
+++ b/postgis/build/postgis-2.5.4/raster/rt_pg/rtpg_mapalgebra.c
@@ -934,10 +934,8 @@ Datum RASTER_nMapAlgebra(PG_FUNCTION_ARGS)
 			i = arg->numraster - 1;
 			break;
 		case ET_SECOND:
-			if (arg->numraster > 1) {
-				i = 1;
+			i = (arg->numraster > 1) ? 1 : 0;
 			break;
-			}
 		default:
 			i = 0;
 			break;


### PR DESCRIPTION
While building with raster support, it fails with  ```error: this statement may fall through [-Werror=implicit-fallthrough=]```. As it turned out, this feature was introduced in gcc-7, gcc-6 has no such problems. The code will be built under any gcc version.