### PR TITLE
Consider oversized rows for stawidth computation

### DIFF
--- a/postgis/build/postgis-2.5.4/postgis/gserialized_estimate.c
+++ b/postgis/build/postgis-2.5.4/postgis/gserialized_estimate.c
@@ -1797,7 +1797,7 @@ compute_gserialized_stats_mode(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfu
 	stats->stanumbers[stats_slot] = (float4*)nd_stats;
 	stats->numnumbers[stats_slot] = nd_stats_size/sizeof(float4);
 	stats->stanullfrac = (float4)null_cnt/sample_rows;
-	stats->stawidth = total_width/notnull_cnt;
+	stats->stawidth = (total_width + stats->totalwidelength) / (double) (notnull_cnt + stats->widerow_num);
 	stats->stadistinct = -1.0;
 	stats->stats_valid = true;
 


### PR DESCRIPTION
When store the geometric attributes in the pages, we firstly try to keep them in main tuple uncompressed, and stored compressed inline when the tuple doesn't fit into a page. Tables with geometric types usually have more oversized rows, and the stawidth is far smaller than the real average width.

The wrong stawidth value causes gp_bloat_diag view shows tables have bloat and require a "VACUUM" or "VACUUM FULL", although these tables don't have bloat in fact. Include the total length and number of oversized rows when computing the stawidth.