### PR TITLE
fix issue of LWSIZE_GET/LWSIZE_SET

### DIFF
--- a/postgis/build/postgis-3.3.2/liblwgeom/liblwgeom.h.in
+++ b/postgis/build/postgis-3.3.2/liblwgeom/liblwgeom.h.in
@@ -330,16 +330,20 @@ typedef struct lwvarlena_t
 * Cribbed from PgSQL, top 30 bits are size. Use VARSIZE() when working
 * internally with PgSQL. See SET_VARSIZE_4B / VARSIZE_4B in
 * PGSRC/src/include/postgres.h for details.
+*
+* GPDB:
+* Note the definitions of SET_VARSIZE_4B / VARSIZE_4B are different
+* in PgSQL/GPDB, so we have to change the definitions here to be align
+* to GPDB.
 */
 #ifdef WORDS_BIGENDIAN
-#define LWSIZE_GET(varsize) ((varsize) & 0x3FFFFFFF)
-#define LWSIZE_SET(varsize, len) ((varsize) = ((len) & 0x3FFFFFFF))
 #define IS_BIG_ENDIAN 1
 #else
-#define LWSIZE_GET(varsize) (((varsize) >> 2) & 0x3FFFFFFF)
-#define LWSIZE_SET(varsize, len) ((varsize) = (((uint32_t)(len)) << 2))
 #define IS_BIG_ENDIAN 0
 #endif
+
+#define LWSIZE_GET(varsize) (ntohl(varsize) & 0x3FFFFFFF)
+#define LWSIZE_SET(varsize, len) ((varsize) = htonl( (len) & 0x3FFFFFFF ))
 
 /******************************************************************/
 


### PR DESCRIPTION
### Summary

It's a fix of issue https://github.com/greenplum-db/gpdb/issues/15375. See the issue for repro.

### Root cause

Basically, it's due to the different definitions of `SET_VARSIZE_4B` / `VARSIZE_4B` in PgSQL/GPDB. It's the version of PgSQL 12:
```
#ifdef WORDS_BIGENDIAN
#define VARSIZE_4B(PTR) \
    (((varattrib_4b *) (PTR))->va_4byte.va_header & 0x3FFFFFFF)
#else
#define VARSIZE_4B(PTR) \
    ((((varattrib_4b *) (PTR))->va_4byte.va_header >> 2) & 0x3FFFFFFF)
```
And it's the version of GPDB7:
```
#define VARSIZE_4B(PTR) \
    (ntohl(((varattrib_4b *) (PTR))->va_4byte.va_header) & 0x3FFFFFFF)
```
GPDB uses `ntohl()`/`htonl()` to eliminate the differences of big-/small-endian env, and the side effect is that the format of `varlena` was changed.

Postgis 3.3 copied the struct `varlena` and created a new struct `lwvarlena_t`:
```
/******************************************************************
* LWGEOM varlena equivalent type that contains both the size and
* data(see Postgresql c.h)
*/
typedef struct lwvarlena_t
{
    uint32_t    size;   /* Do not touch this field directly! */
    char        data[]; /* Data content is here */
} lwvarlena_t;
```
and copied `SET_VARSIZE_4B` / `VARSIZE_4B` to new functions `LWSIZE_GET`/`LWSIZE_SET`:
```
#ifdef WORDS_BIGENDIAN
#ifdef WORDS_BIGENDIAN
#define LWSIZE_GET(varsize) ((varsize) & 0x3FFFFFFF)
#define LWSIZE_SET(varsize, len) ((varsize) = ((len) & 0x3FFFFFFF))
#define IS_BIG_ENDIAN 1
#define IS_BIG_ENDIAN 1
#else
#else
#define LWSIZE_GET(varsize) (((varsize) >> 2) & 0x3FFFFFFF)
#define LWSIZE_SET(varsize, len) ((varsize) = (((uint32_t)(len)) << 2))
#define IS_BIG_ENDIAN 0
#define IS_BIG_ENDIAN 0
#endif
```
The result is, the code works on PgSQL, but doesn't work on GPDB.

### Fix

Modifying `LWSIZE_GET`/`LWSIZE_SET` according to the definitions of GPDB7:
```
#define LWSIZE_GET(varsize) (ntohl(varsize) & 0x3FFFFFFF)
#define LWSIZE_SET(varsize, len) ((varsize) = htonl( (len) & 0x3FFFFFFF ))
```
### Test
The scenario has been covered by existing tests.
### A further question
Comparing to changing `LWSIZE_GET`/`LWSIZE_SET` to be aligned to GPDB, is it better to change the definition of `SET_VARSIZE_4B` / `VARSIZE_4B` in GPDB to be aligned to PgSQL? We always need to be aligned to upstream if possible, but it might be pretty risky here. I tried to dig the reason why we used different definitions from PgSQL, but didn't get the answer. You comment is welcome here.