### PR TITLE
Fix orca job failure

### DIFF
--- a/postgis/build/postgis-3.3.2/extensions/postgis_tiger_geocoder/sql/test-normalize_address.sql
+++ b/postgis/build/postgis-3.3.2/extensions/postgis_tiger_geocoder/sql/test-normalize_address.sql
@@ -1,4 +1,5 @@
 \t on \a \set ECHO none
+set client_min_messages to WARNING;
 --\timing
 SELECT '#887' As ticket, * FROM normalize_address('2450 N COLORADO ST, PHILADELPHIA, PA, 19132');
 SELECT '#1051a' As ticket, * FROM normalize_address('212 3rd Ave N Suite 560, Minneapolis, MN 55401');

--- a/postgis/build/postgis-3.3.2/extensions/postgis_tiger_geocoder/sql/test-pagc_normalize_address.sql
+++ b/postgis/build/postgis-3.3.2/extensions/postgis_tiger_geocoder/sql/test-pagc_normalize_address.sql
@@ -1,4 +1,6 @@
 \t on \a \set ECHO none
+set client_min_messages to WARNING;
+
 SELECT set_geocode_setting('use_pagc_address_parser', 'true');
 --\timing
 SELECT '#887' As ticket, * FROM normalize_address('2450 N COLORADO ST, PHILADELPHIA, PA, 19132');

--- a/postgis/build/postgis-3.3.2/regress/core/tickets.sql
+++ b/postgis/build/postgis-3.3.2/regress/core/tickets.sql
@@ -256,6 +256,7 @@ FROM utm_dots
 WHERE ST_Area(ST_Buffer(the_geog,10)) NOT between 307 and 315
 LIMIT 10;
 
+ANALYZE utm_dots;
 SELECT '#304.a', Count(*) FROM utm_dots WHERE ST_DWithin(the_geog, 'POINT(0 0)'::geography, 3000000);
 
 CREATE INDEX utm_dots_gix ON utm_dots USING GIST (the_geog);


### PR DESCRIPTION
Failed test:  ./regress/core/tickets .. failed (diff expected obtained: /tmp/pgis_reg/test_82_diff) with following reason
`NOTICE:  One or more columns in the following table(s) do not have statistics: utm_dots`

 Fix: the notice was because analyze <tablename> was not performed for the test and the minimum log level was set to notice causing this diff. Added `analyze utm_dots;` instruction to the test query.