### PR TITLE
Added libtiff dep check for gppkg

### DIFF
--- a/postgis/package/gppkg_spec_v2.yml.in
+++ b/postgis/package/gppkg_spec_v2.yml.in
@@ -5,11 +5,18 @@ OS: #os
 GPDBVersion: #gpver
 Version: ossv3.3.2+pivotal.1_pv3.3_gpdb7.0
 Description: PostGIS provides spatial database functions for the Greenplum Database.
+PreInstall:
+  All: |
+       # Check if libtiff.so.* is available in the shared library cache
+       if ! ldconfig -N -p 2> /dev/null | grep -P '^\tlibtiff.so\.'; then
+           echo "libtiff.so.* is not available. Please install the required library."
+           exit 1
+       fi
 PostInstall:
-  Coordinator: |
+  All: |
       echo "Please run the following commands to enable the PostGIS package:"
       echo "CREATE EXTENSION postgis;"
 PostUpdate:
-  Coordinator: |
+  All: |
       echo "Please run the following commands to finish the upgrade:"
       echo '$GPHOME/share/postgresql/contrib/postgis-3.3/postgis_manager.sh mydatabase upgrade'


### PR DESCRIPTION
Issue:
if the ibtiff is not available still the postgis gppkg is getting installed.  this causing the issue while creating a postgis extension for database.

Fix: added depedency check in .spec file as part of preinstall script.

In gppkg there is plan to add dependency check as part of host requirement, but that yet to implement. so for now adding check in spec file to error out if libtiff is not available.