### PR TITLE
Substituting global static variable definition with a 'Distributed Replicated' approach

### DIFF
--- a/postgis/build/postgis-3.3.2/libpgcommon/lwgeom_cache.c
+++ b/postgis/build/postgis-3.3.2/libpgcommon/lwgeom_cache.c
@@ -283,13 +283,15 @@ getSRSbySRID(FunctionCallInfo fcinfo, int32_t srid, bool short_crs)
         return NULL;
     }
 
-    if (getSRSbySRIDbyRule(srid, short_crs, query) != NULL) {
-        size = strlen(query) + 1;
-        srscopy = SPI_palloc(size);
-        memcpy(srscopy, query, size);
-        SPI_finish();
-        return srscopy;
-    }
+    /*
+    * if (getSRSbySRIDbyRule(srid, short_crs, query) != NULL) {
+    *   size = strlen(query) + 1;
+    *   srscopy = SPI_palloc(size);
+    *   memcpy(srscopy, query, size);
+    *   SPI_finish();
+    *   return srscopy;
+    *  }
+    */
 
     if (short_crs)
         snprintf(query,
@@ -388,10 +390,11 @@ getSRIDbySRS(FunctionCallInfo fcinfo, const char *srs)
     Datum values[] = {CStringGetDatum(srs)};
     int32_t srid, err;
 
-    srid = getSRIDbySRSbyRule(srs);
-    if (srid != 0) {
-        return srid;
-    }
+    /* srid = getSRIDbySRSbyRule(srs);
+    * if (srid != 0) {
+    *    return srid;
+    * }
+    */
 
     postgis_initialize_cache();
     snprintf(query,

--- a/postgis/build/postgis-3.3.2/libpgcommon/lwgeom_transform.c
+++ b/postgis/build/postgis-3.3.2/libpgcommon/lwgeom_transform.c
@@ -196,14 +196,15 @@ GetProjStringsSPI(int32_t srid)
      *  otherwise we will meet the known issue: cannot access relation from segments.
      *  so we search static hash table firstly to by-pass this issue issue.
      */
-	static int maxproj4len = 512;
-	char *proj4_string = getProj4StringStatic(srid);
-	if (proj4_string != NULL) {
-		strs.proj4text = SPI_pstrdup(proj4_string);
-		SPI_finish();
-		return strs;
-	}
-
+	/* static int maxproj4len = 512;
+	* char *proj4_string = getProj4StringStatic(srid);
+	* if (proj4_string != NULL) {
+	*	strs.proj4text = SPI_pstrdup(proj4_string);
+	*	SPI_finish();
+	*	return strs;
+	* }
+    */
+   
 	static char *proj_str_tmpl =
 	    "SELECT proj4text, auth_name, auth_srid, srtext "
 	    "FROM %s "

--- a/postgis/build/postgis-3.3.2/postgis/postgis.sql.in
+++ b/postgis/build/postgis-3.3.2/postgis/postgis.sql.in
@@ -2036,7 +2036,7 @@ CREATE TABLE spatial_ref_sys (
 	 auth_srid integer,
 	 srtext varchar(2048),
 	 proj4text varchar(2048)
-);
+) Distributed Replicated;
 
 -----------------------------------------------------------------------
 -- POPULATE_GEOMETRY_COLUMNS()


### PR DESCRIPTION
Adopting the 'Distributed Replicated' pattern instead of defining global static variables, for facilitating the later expansion and maintenance of spatial_ref_sys. Additionally, there is a requirement for modifications to the spatial_ref_sys table in practical scenarios.