### PR TITLE
Fix tiger and raster tests

### DIFF
--- a/postgis/build/postgis-3.3.2/extensions/postgis_tiger_geocoder/Makefile.in
+++ b/postgis/build/postgis-3.3.2/extensions/postgis_tiger_geocoder/Makefile.in
@@ -29,7 +29,7 @@ DATA_built = \
 	$(NULL)
 
 REGRESS = test-normalize_address ##test-upgrade
-REGRESS_OPTS = --load-extension=fuzzystrmatch --load-extension=postgis --load-extension=$(EXTENSION)
+REGRESS_OPTS = --load-language=plpython3u --load-extension=fuzzystrmatch --load-extension=postgis --load-extension=$(EXTENSION)
 
 SQL_BITS     = $(wildcard sql_bits/*.sql)
 EXTRA_CLEAN = sql expected ${SQL_BITS}

--- a/postgis/build/postgis-3.3.2/extensions/postgis_tiger_geocoder/sql/tiger_geocoder_upgrade_minor.sql
+++ b/postgis/build/postgis-3.3.2/extensions/postgis_tiger_geocoder/sql/tiger_geocoder_upgrade_minor.sql
@@ -617,8 +617,6 @@ AND platform.os = $2  -- generate script for selected platform
 $BODY$
   LANGUAGE sql VOLATILE;
 
-CREATE OR REPLACE LANGUAGE plpython3u;
-
 CREATE OR REPLACE FUNCTION loader_generate_script_py(param_states text[], os text)
   RETURNS text AS
 $BODY$

--- a/postgis/build/postgis-3.3.2/extras/tiger_geocoder/tiger_loader_2022.sql
+++ b/postgis/build/postgis-3.3.2/extras/tiger_geocoder/tiger_loader_2022.sql
@@ -461,8 +461,6 @@ WHERE platform.os = $1 -- generate script for selected platform
 $BODY$
   LANGUAGE sql VOLATILE;
 
-CREATE OR REPLACE LANGUAGE plpython3u;
-
 CREATE OR REPLACE FUNCTION loader_generate_script(param_states text[], os text)
   RETURNS text AS
 $BODY$

--- a/postgis/build/postgis-3.3.2/raster/test/regress/rt_union.sql
+++ b/postgis/build/postgis-3.3.2/raster/test/regress/rt_union.sql
@@ -1,3 +1,4 @@
+SET optimizer = off;
 DROP TABLE IF EXISTS raster_union_in;
 CREATE TABLE raster_union_in (
 	rid integer,
@@ -459,3 +460,4 @@ SELECT 'none', ST_Union(r) from ( select null::raster r where false ) f;
 SELECT 'null', ST_Union(null::raster);
 --#4699 crash
 SELECT 'null-1', ST_Union(null::raster,1);
+RESET optimizer;


### PR DESCRIPTION
Tiger installer creates plpython which was necessary for the tests but it actually breaks the installation if the db already has the language. Instead we add the language loading work to the pg_regress.

We also disable orca for one the raster tests since it was giving sporadic errors.
CI: https://dev2.ci.gpdb.pivotal.io/teams/gp-ai/pipelines/h3-dist