### PR TITLE
Updated gppkg spec file to change postgis version

### DIFF
--- a/postgis/package/gppkg_spec_v2.yml.in
+++ b/postgis/package/gppkg_spec_v2.yml.in
@@ -3,7 +3,7 @@ Pkgname: postgis
 Architecture: #arch
 OS: #os
 GPDBVersion: #gpver
-Version: ossv3.3.2+pivotal.1_pv3.3_gpdb7.0
+Version: ossv3.3.2+pivotal.2_pv3.3_gpdb7.1
 Description: PostGIS provides spatial database functions for the Greenplum Database.
 PreInstall:
   All: |


### PR DESCRIPTION
Updated gppkg v2 spec file to include latest postgis version number. This version numbering is used by gppkg utility in commands like `gppkg list`