### PR TITLE
Fix installation issue on EL9 and bump patch version to pivotal.9

### DIFF
--- a/postgis/package/Makefile
+++ b/postgis/package/Makefile
@@ -31,34 +31,34 @@ include ../Makefile.version
 #GOES
 GEOS_DIR=$(EXT_TOP)/geos-$(GEOS_VER)
 GEOS_CONFIG=$(GEOS_DIR)/bin/geos-config
-GEOS_RPM_FLAGS="--define 'geos_dir $(GEOS_DIR)' --define 'geos_ver $(GEOS_VER)' --define 'geos_rel $(GEOS_REL)'"
+GEOS_RPM_FLAGS="--define 'geos_dir $(GEOS_DIR)' --define 'geos_ver $(GEOS_VER)' --define '_build_id_links none' --define 'geos_rel $(GEOS_REL)'"
 GEOS_RPM=geos-$(GEOS_VER)-$(GEOS_REL).$(ARCH).rpm
 
 #Proj.4
 PROJ_DIR=$(EXT_TOP)/proj-$(PROJ_VER)
-PROJ_RPM_FLAGS="--define 'proj_dir $(PROJ_DIR)' --define 'proj_ver $(PROJ_VER)' --define 'proj_rel $(PROJ_REL)'"
+PROJ_RPM_FLAGS="--define 'proj_dir $(PROJ_DIR)' --define 'proj_ver $(PROJ_VER)' --define '_build_id_links none' --define 'proj_rel $(PROJ_REL)'"
 PROJ_RPM=proj-$(PROJ_VER)-$(PROJ_REL).$(ARCH).rpm
 
 #json-c
 JSON_DIR=$(EXT_TOP)/json-c-$(JSON_VER)
-JSON_RPM_FLAGS="--define 'json_dir $(JSON_DIR)' --define 'json_ver $(JSON_VER)' --define 'json_rel $(JSON_REL)'"
+JSON_RPM_FLAGS="--define 'json_dir $(JSON_DIR)' --define 'json_ver $(JSON_VER)' --define '_build_id_links none' --define 'json_rel $(JSON_REL)'"
 JSON_RPM=json-c-$(JSON_VER)-$(JSON_REL).$(ARCH).rpm
 
 #GDAL
 GDAL_DIR=$(EXT_TOP)/gdal-$(GDAL_VER)
 GDAL_CONFIG=$(GDAL_DIR)/bin/gdal-config
-GDAL_RPM_FLAGS="--define 'gdal_dir $(GDAL_DIR)' --define 'gdal_ver $(GDAL_VER)' --define 'gdal_rel $(GDAL_REL)' --define 'libexpat_ver $(LIBEXPAT_VER)' --define 'libexpat_rel $(LIBEXPAT_REL)'"
+GDAL_RPM_FLAGS="--define 'gdal_dir $(GDAL_DIR)' --define 'gdal_ver $(GDAL_VER)' --define '_build_id_links none' --define 'gdal_rel $(GDAL_REL)' --define 'libexpat_ver $(LIBEXPAT_VER)' --define 'libexpat_rel $(LIBEXPAT_REL)'"
 GDAL_RPM=gdal-$(GDAL_VER)-$(GDAL_REL).$(ARCH).rpm
 
 # LIBEXPAT
 LIBEXPAT_DIR=$(EXT_TOP)/libexpat-$(LIBEXPAT_VER)
-LIBEXPAT_RPM_FLAGS="--define 'libexpat_dir $(LIBEXPAT_DIR)' --define 'libexpat_ver $(LIBEXPAT_VER)' --define 'libexpat_rel $(LIBEXPAT_REL)'"
+LIBEXPAT_RPM_FLAGS="--define 'libexpat_dir $(LIBEXPAT_DIR)' --define '_build_id_links none' --define 'libexpat_ver $(LIBEXPAT_VER)' --define 'libexpat_rel $(LIBEXPAT_REL)'"
 LIBEXPAT_RPM=libexpat-$(LIBEXPAT_VER)-$(LIBEXPAT_REL).$(ARCH).rpm
 
 # POSTGIS
 POSTGIS_DIR=$(shell cd ../build/postgis-$(POSTGIS_VER) && pwd)
 POSTGIS_PKG_VER=ossv$(POSTGIS_VER)_pv$(PIVOTAL_VER)_gpdb$(GPDB_VER)orca
-POSTGIS_RPM_FLAGS="--define 'bld_top $(BLD_TOP)' --define 'postgis_dir $(POSTGIS_DIR)' --define 'postgis_ver $(POSTGIS_VER)' --define 'postgis_rel $(POSTGIS_REL)' --define 'geos_ver $(GEOS_VER)' --define 'proj_ver $(PROJ_VER)' --define 'json_ver $(JSON_VER)' --define 'gdal_ver $(GDAL_VER)' --define 'libexpat_ver $(LIBEXPAT_VER)'"
+POSTGIS_RPM_FLAGS="--define 'bld_top $(BLD_TOP)' --define '_build_id_links none' --define 'postgis_dir $(POSTGIS_DIR)' --define 'postgis_ver $(POSTGIS_VER)' --define 'postgis_rel $(POSTGIS_REL)' --define 'geos_ver $(GEOS_VER)' --define 'proj_ver $(PROJ_VER)' --define 'json_ver $(JSON_VER)' --define 'gdal_ver $(GDAL_VER)' --define 'libexpat_ver $(LIBEXPAT_VER)'"
 DEPENDENT_RPMS="$(GEOS_RPM) $(PROJ_RPM) $(JSON_RPM) $(GDAL_RPM) $(LIBEXPAT_RPM)"
 POSTGIS_RPM=postgis-$(POSTGIS_VER)-$(POSTGIS_REL).$(ARCH).rpm
 

--- a/postgis/package/gppkg_spec.yml.in
+++ b/postgis/package/gppkg_spec.yml.in
@@ -1,7 +1,7 @@
 Pkgname: postgis
 Architecture: #arch
 OS: #os
-Version: ossv2.5.4+pivotal.8_pv2.5_gpdb6.0
+Version: ossv2.5.4+pivotal.9_pv2.5_gpdb6.0
 GPDBVersion: #gpver
 Description: PostGIS provides spatial database functions for the Greenplum Database.
 PostInstall:


### PR DESCRIPTION
This commit fixes issue with postgis-2.5.4 installation on EL9 platform. Without the `_build_id_links` set to `none` RPM build creates symbolic links to build ID files which are causing permission denied issues while installing gppkg on EL9. Hence  set this flag to none to avoid rpmbuild creating symbolic links which aren't anyway necessary for postgis installation. Also, updated the postgis patch version.

Here's pipeline after change: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/postgis-254